### PR TITLE
Update requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to run the scripts in this repo, you must have python3  and pip install
 
 ## installation
 
-from the `dc-law-tools` directory run `pip install .`
+from the `dc-law-tools` directory run `pip install -r requirements.txt`
 
 ## build commands
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ lxml==3.4.4
 tqdm==3.4.0
 click==6.2
 UniversalClient==0.6.4
+Arpeggio==1.5
+moment==0.5.1
+elasticsearch>=2.0.0,<3.0.0


### PR DESCRIPTION
Updated `requirements.txt` with missing libraries.

Update `README.md` to make pip install from `requirements.txt`. There isn't a `setup.py` but the alternative works fine.

Question though. Which version of elasticsearch is the intended target? I'm using elasticsearch 1.x. If elasticsearch 1.x is the intended target, then what I have in `requirements.txt` is fine. If 2.x, then it will have to change to ` elasticsearch>=2.0.0,<3.0.0`.

I, Sean Brewer (@seabre), license this pull request under the CC0 license.